### PR TITLE
Removed that pesky Game Mode and Decrease autocall

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -174,7 +174,7 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.Server | AdminFlags.Mapping, min: 0, max: int.MaxValue)]
     public static readonly CVarDef<int> EmergencyShuttleAutoCallTime =
-        CVarDef.Create("shuttle.auto_call_time", 90, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.auto_call_time", 85, CVar.SERVERONLY);
 
     /// <summary>
     ///     Time in minutes after the round was extended (by recalling the shuttle) to call

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -7,12 +7,12 @@
     Changeling: 0.15 # goob
     Heretics: 0.15 # goob
     Survival: 0.09 # previously 0.10
-    Revolutionary: 0.05 # previously 0.05
+    #Revolutionary: 0.05 # Moist Change - removed from imp
     SpyVsSpy: 0.03 # imp
     Zombie: 0.04 # previously 0.05
     Wizard: 0.02 # previously 0.05, disabled roundstart upstream
     Zombieteors: 0.01 # imp - removed from upstream
-    KesslerSyndrome: 0.01 # imp - removed from upstream
+    # KesslerSyndrome: 0.01 # Moist change - removed from imp
 
     # lowpop versions of above gamemodes - intended for < 20 population
     LowpopHeretics: 0.15


### PR DESCRIPTION
This PR does three things:
- removed Revolution as a game mode from secret
- removed Kessler as a game mode from secret
- changes the Auto Call timer from 90 minutes to 85 minutes