### PR TITLE
Scrap Generator Fulton Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -29,7 +29,7 @@
   - type: NonMobStatusIcon #imp edit. for the salvohud
 
 - type: entity
-  parent: BaseStructure
+  parent: BaseStructureDynamic # Moist change - BaseStructure -> BaseStructureDynamic - allows generator scrap to be fultoned
   id: BaseScrapLarge
   abstract: true
   name: scrap


### PR DESCRIPTION
Allows scrap generators to be fultoned by changing BaseScrapLarge's parent from BaseStructure to BaseStructureDynamic