### PR TITLE
Lift Arachnid Dietary Restrictions

### DIFF
--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   id: OrganArachnidStomach
-  parent: OrganAnimalStomach
+  parent: BaseHumanOrgan # Moist change
   name: arachnid stomach #imp edit
   description: "Gross. This is hard to stomach."
   components:
@@ -43,6 +43,9 @@
     specialDigestible:  #imp edit
       tags:
       - SpiderFood
+      - Meat # Moist change
+      - Raw # Moist change
+      - Organ # Moist change
     isSpecialDigestibleExclusive: false # imp
   - type: SolutionContainerManager
     solutions:
@@ -55,7 +58,7 @@
           Quantity: 5
   - type: Metabolizer
     updateInterval: 1.5
-    metabolizerTypes: [ Animal ]
+    metabolizerTypes: [ Human ]  # Moist change
   - type: Tag # goob edit
     tags:
     - Meat

--- a/Resources/ServerInfo/_Impstation/Guidebook/Mobs/Arachnid.xml
+++ b/Resources/ServerInfo/_Impstation/Guidebook/Mobs/Arachnid.xml
@@ -8,7 +8,7 @@
   Arachnids can use their vestigial back-limbs to carry more items at one time than other species. [color=#1e90ff]This means they have two extra "Pocket" slots.[/color]
 
   ## Dietary Restrictions
-  Their species has developed strong stomach enzymes capable of breaking down uncooked proteins more efficiently, [color=#1e90ff]enabling them to eat raw meat without experiencing any ill effects.[/color] However, this adaptation has rendered their stomachs more sensitive to certain alkaloids, [color=#ffa500]causing foods which contain theobromine or allicin (like chocolate and onions) to be poisonous to them.[/color]
+  Their species has developed strong stomach enzymes capable of breaking down uncooked proteins more efficiently, [color=#1e90ff]enabling them to eat raw meat without experiencing any ill effects.[/color] <!--However, this adaptation has rendered their stomachs more sensitive to certain alkaloids, [color=#ffa500]causing foods which contain theobromine or allicin (like chocolate and onions) to be poisonous to them.[/color]--> <!--Moist change to reflect lifting of dietary restrictions-->
 
   ## Damage
   Like most invertebrates, Arachnids breathe through many spiracles, or small holes, distributed across the surface of their body. As a result, [color=#ffa500]they suffocate 50% faster than other species.[/color]


### PR DESCRIPTION
Lifts arachnid dietary restrictions per https://github.com/Luquos/MoistStation/issues/28

Reparents OrganArachnidStomach to BaseHumanOrgan and gives it the Human metabolizerType, adds Meat, Raw, and Organ to the organ's specialDigestible tags. 

Tested, coffee no longer poisons arachnids, raw meat does not poison them, blood does not restore blood level so we're winning.