### PR TITLE
Customize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<p align="center"> <img alt="Impstation" src="https://github.com/impstation/imp-station-14/blob/master/Resources/Textures/Logo/logo.png" /></p>
+<p align="center"> <img alt="Eresos" src="https://github.com/Luquos/MoistStation/blob/MoistImping/Resources/Textures/Logo/logo.png" /></p>
 
-Eresos Imp Station is a fork of Space Station 14, a remake of SS13 that runs on [Robust Toolbox](https://github.com/space-wizards/RobustToolbox), a homegrown engine written in C#.
+Eresos Station (this branch) is a fork of the Imp Station fork of Space Station 14, a remake of SS13 that runs on [Robust Toolbox](https://github.com/space-wizards/RobustToolbox), a homegrown engine written in C#.
 
 ## Links
 [Website](https://impstation.gay/) | [Steam](https://store.steampowered.com/app/1255460/Space_Station_14/) | [Standalone Download](https://spacestation14.io/about/nightlies/)
@@ -14,13 +14,13 @@ Additionally, see these resources for license and attribution information:
 
 ## Contributing
 
-We are happy to accept contributions from anybody. Get in Discord if you want to help. We've got a [list of issues](https://github.com/impstation/imp-station-14/issues) that need to be done and anybody can pick them up. Don't be afraid to ask for help either!
+We are not currently looking for contributions from outside our player base.
 
 As a baseline make sure your changes and pull requests are in accordance with the upstream [contribution guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). We're generally not as strict, but it's good practice to follow these examples.
 
-If you are adding completely custom content that would go into the normal SS14 file structure in a certain spot, add that content to the `_Impstation` folder with that same file path instead. For example, when adding the GBsay chat command for ghost bar stuff, it would have gone in `Content.Server/Chat/Commands`. Instead, the `GBsay.cs` file is in `Content.Server/_Impstation/Chat/Commands`.
+If you are adding completely custom content please make sure you've run it by the maints in the Discord, as we are trying to limit how much custom content we have for maintainability reasons. Imp and Wizden are generally better places for new content.
 
-The Impstation folders are located at `Content.Client/_Impstation`, `Content.Server/_Impstation`, and `Content.Shared/_Impstation`. The Resources folder is kind of its own beast, and has a lot of depth. For that reason it makes sense to have the _Impstation folder inside of the subfolder it is modifying. As another example, the main prototypes folder for our  custom content is located in `Resources/Prototypes/_Impstation`. The custom Spy vs Spy gamemode is defined in `Resources/Prototypes/_Impstation/GameRules/roundstart.yml`. This applies for recipies, clothing, everything.
+If you are adding completely custom content anyways and it would go into the normal SS14 file structure in a certain spot, add that content to the `_Moist` folder with that same file path instead. The `_Moist` folder should be at the same level as other fork folders like `_Impstation`.
 
 Keeping things defined like this makes the lives of the people maintaining the server much, much easier.
 
@@ -34,23 +34,6 @@ This project does not accept low-effort or wholesale AI-generated contributions.
 - Auto-generated documentation, issue reports or pull request descriptions.
 
 Exceptions to this are simple tools like Rider's single-line completion feature
-
-## Building
-
-1. Clone this repo:
-```shell
-git clone https://github.com/impstation/imp-station-14.git
-```
-2. Go to the project folder and run `RUN_THIS.py` to initialize the submodules and load the engine:
-```shell
-cd imp-station-14
-python RUN_THIS.py
-```
-3. Compile the solution:
-
-Build the server using `dotnet build`.
-
-[More detailed instructions on building the project.](https://docs.spacestation14.com/en/general-development/setup.html)
 
 ## License
 


### PR DESCRIPTION
Updates to the MoistImping branch's readme. Make it clear that we aren't Imp, and we aren't currently looking for contributions from outside our player base. Remove the building instructions so we don't have to update them if we ever rename this branch as part of making it the default branch.